### PR TITLE
feat: add update poster method and tests

### DIFF
--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -15,4 +15,15 @@ class Api::V1::PostersController < ApplicationController
         render json: PosterSerializer.format_poster(poster)
     end
 
+    def update 
+        poster = Poster.update(params[:id], poster_params)
+        render json: PosterSerializer.format_poster(poster)
+    end
+
+    private
+
+    def poster_params
+        params.require(:poster).permit(:id, :name, :description, :price, :year, :vintage, :img_url)
+    end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
   
   get "/api/v1/posters/:id", to: "api/v1/posters#show"
+  patch "/api/v1/posters/:id", to: "api/v1/posters#update"
   # Defines the root path route ("/")
   # root "posts#index"
 

--- a/spec/requests/api/v1/posters_request_spec.rb
+++ b/spec/requests/api/v1/posters_request_spec.rb
@@ -88,6 +88,57 @@ describe "Posters API" do
             expect(attributes).to have_key(:img_url)
             expect(attributes[:img_url]).to be_a(String)
     end
+
+    it 'can update a poster' do
+        poster = Poster.create(
+            name: "MEDIOCRITY", 
+            description: "Dreams are just that—dreams.", 
+            price: 127.00, 
+            year: 2021, 
+            vintage: false, 
+            img_url: "https://images.unsplash.com/photo-1551993005-75c4131b6bd8")
+
+        id = poster.id
+    
+        patch "/api/v1/posters/#{id}", params: {
+            poster: {
+            name: "STUPIDITY",
+            description: "Reality hits hard.",
+            price: 150.00,
+            year: 2022,
+            vintage: true,
+            img_url: "https://images.unsplash.com/photo-1551993005-75c4131b6bd8"
+    }
+    }
+    
+        updated_poster = JSON.parse(response.body, symbolize_names: true)
+    
+        expect(response).to be_successful
+
+        expect(updated_poster).to have_key(:data)
+
+        expect(updated_poster[:data]).to have_key(:attributes)
+
+        attributes = updated_poster[:data][:attributes]
+
+        expect(attributes).to have_key(:name)
+        expect(attributes[:name]).to eq("STUPIDITY")
+
+        expect(attributes).to have_key(:description)
+        expect(attributes[:description]).to eq("Reality hits hard.")
+
+        expect(attributes).to have_key(:price)
+        expect(attributes[:price]).to eq(150.0)
+
+        expect(attributes).to have_key(:vintage)
+        expect(attributes[:vintage]).to eq(true)
+
+        expect(attributes).to have_key(:year)
+        expect(attributes[:year]).to eq(2022)
+
+        expect(attributes).to have_key(:img_url)
+        expect(attributes[:img_url]).to eq("https://images.unsplash.com/photo-1551993005-75c4131b6bd8")
+    end
 end
 
 


### PR DESCRIPTION
This PR adds a method to update a poster, along with related tests.