### PR TITLE
Destroy poster and meta count

### DIFF
--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::PostersController < ApplicationController
     def index
-        render json: Poster.all
+        posters = Poster.all
+        render json: PosterSerializer.format_posters(posters)
     end
 
     def create

--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -18,8 +18,10 @@ class Api::V1::PostersController < ApplicationController
         render json: PosterSerializer.format_poster(poster)
     end
 
-    def destroy
-        render json: Poster.delete(params[:id])
+    def delete
+        poster = Poster.find(params[:id])
+        poster.destroy
+        head :no_content
     end
 
     private

--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -8,13 +8,6 @@ class Api::V1::PostersController < ApplicationController
         render json: PosterSerializer.format_poster(poster)
     end
 
-
-
-
-
-
-
-
     def show
         poster = Poster.find(params[:id])
         render json: PosterSerializer.format_poster(poster)
@@ -23,6 +16,10 @@ class Api::V1::PostersController < ApplicationController
     def update 
         poster = Poster.update(params[:id], poster_params)
         render json: PosterSerializer.format_poster(poster)
+    end
+
+    def destroy
+        render json: Poster.delete(params[:id])
     end
 
     private

--- a/app/serializers/poster_serializer.rb
+++ b/app/serializers/poster_serializer.rb
@@ -1,4 +1,26 @@
 class PosterSerializer
+    def self.format_posters(posters)
+        posters.map do |poster|
+        {
+            data: [
+                id: poster.id,
+                type: "poster",
+                attributes: {
+                    name: poster.name,
+                    description: poster.description,
+                    price: poster.price,
+                    year: poster.year,
+                    vintage: poster.vintage,
+                    img_url: poster.img_url
+                }
+            ],
+            meta: {
+                count: posters.count
+            }
+        }
+    end
+    end
+
     def self.format_poster(poster)
         {
             data: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   post "/api/v1/posters", to: "api/v1/posters#create"
   get "/api/v1/posters/:id", to: "api/v1/posters#show"
   patch "/api/v1/posters/:id", to: "api/v1/posters#update"
+  delete "/api/v1/posters/:id", to: "api/v1/posters#destroy"
   # Defines the root path route ("/")
   # root "posts#index"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   post "/api/v1/posters", to: "api/v1/posters#create"
   get "/api/v1/posters/:id", to: "api/v1/posters#show"
   patch "/api/v1/posters/:id", to: "api/v1/posters#update"
-  delete "/api/v1/posters/:id", to: "api/v1/posters#destroy"
+  delete "/api/v1/posters/:id", to: "api/v1/posters#delete"
   # Defines the root path route ("/")
   # root "posts#index"
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,11 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 # that will avoid rails generators crashing because migrations haven't been run yet
 # return unless Rails.env.test?
 require 'rspec/rails'
+RSpec.configure do |config|
+  config.before(:each) do
+    Poster.destroy_all
+  end
+end
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/requests/api/v1/posters_request_spec.rb
+++ b/spec/requests/api/v1/posters_request_spec.rb
@@ -92,52 +92,6 @@ expect(created_poster.img_url).to eq(poster_params[:img_url])
 
 end
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-describe "Posters API" do
     it "can get one poster by its id" do
         id = Poster.create(
             name: "MEDIOCRITY", 
@@ -228,7 +182,24 @@ describe "Posters API" do
         expect(attributes).to have_key(:img_url)
         expect(attributes[:img_url]).to eq("https://images.unsplash.com/photo-1551993005-75c4131b6bd8")
     end
-end
+
+    it 'can destroy a poster by id' do
+        poster = Poster.create(
+            name: "MEDIOCRITY", 
+            description: "Dreams are just that—dreams.", 
+            price: 127.00, 
+            year: 2021, 
+            vintage: false, 
+            img_url: "https://images.unsplash.com/photo-1551993005-75c4131b6bd8")
+
+        id = poster.id
+
+        delete "/api/v1/posters/#{id}"
+
+        expect(response).to be_successful
+        expect(response).to have_http_status(204)
+    end
+
 end
 
 


### PR DESCRIPTION
This PR adds a delete poster function and associated tests. It also adds a format posters function to the serializer to ensure the meta: count functionality was working properly. We can change this later if you figure out the json gem you were working on.

This PR also adds some RSpec configuration to the rails_helper file to ensure all posters are deleted before running each test. This prevents duplicate posters from being created, which was resulting in errors in some of our tests. 